### PR TITLE
THRIFT-3252 Missing TConcurrentClientSyncInfo.h in cpp Makefile so do…

### DIFF
--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -243,6 +243,7 @@ include_async_HEADERS = \
                      src/thrift/async/TAsyncProcessor.h \
                      src/thrift/async/TAsyncBufferProcessor.h \
                      src/thrift/async/TAsyncProtocolProcessor.h \
+                     src/thrift/async/TConcurrentClientSyncInfo.h \
                      src/thrift/async/TEvhttpClientChannel.h \
                      src/thrift/async/TEvhttpServer.h
 


### PR DESCRIPTION
…esn't

install
Client: cpp
Patch: Adam Beberg