### PR TITLE
THRIFT-3382 TBase class for C++ Library

### DIFF
--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -116,7 +116,8 @@ public:
                                    bool read = true,
                                    bool write = true,
                                    bool swap = false,
-                                   bool stream = false);
+                                   bool stream = false,
+                                   bool is_struct = false);
   void generate_struct_definition(std::ofstream& out,
                                   std::ofstream& force_cpp_out,
                                   t_struct* tstruct,
@@ -368,6 +369,7 @@ void t_cpp_generator::init_generator() {
            << endl
            << "#include <thrift/Thrift.h>" << endl
            << "#include <thrift/TApplicationException.h>" << endl
+           << "#include <thrift/TBase.h>" << endl
            << "#include <thrift/protocol/TProtocol.h>" << endl
            << "#include <thrift/transport/TTransport.h>" << endl
            << endl;
@@ -728,7 +730,7 @@ void t_cpp_generator::generate_forward_declaration(t_struct* tstruct) {
  * @param tstruct The struct definition
  */
 void t_cpp_generator::generate_cpp_struct(t_struct* tstruct, bool is_exception) {
-  generate_struct_declaration(f_types_, tstruct, is_exception, false, true, true, true, true);
+  generate_struct_declaration(f_types_, tstruct, is_exception, false, true, true, true, true, true);
   generate_struct_definition(f_types_impl_, f_types_impl_, tstruct);
 
   std::ofstream& out = (gen_templates_ ? f_types_tcc_ : f_types_impl_);
@@ -872,10 +874,15 @@ void t_cpp_generator::generate_struct_declaration(ofstream& out,
                                                   bool read,
                                                   bool write,
                                                   bool swap,
-                                                  bool stream) {
+                                                  bool stream,
+                                                  bool is_struct) {
   string extends = "";
   if (is_exception) {
     extends = " : public ::apache::thrift::TException";
+  } else {
+    if (is_struct && !gen_templates_) {
+      extends = " : public virtual ::apache::thrift::TBase";
+    }
   }
 
   // Get members

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -156,7 +156,8 @@ include_thrift_HEADERS = \
                          src/thrift/TApplicationException.h \
                          src/thrift/TLogging.h \
                          src/thrift/cxxfunctional.h \
-                         src/thrift/TToString.h
+                         src/thrift/TToString.h \
+                         src/thrift/TBase.h
 
 include_concurrencydir = $(include_thriftdir)/concurrency
 include_concurrency_HEADERS = \

--- a/lib/cpp/src/thrift/TBase.h
+++ b/lib/cpp/src/thrift/TBase.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _THRIFT_TBASE_H_
+#define _THRIFT_TBASE_H_ 1
+
+namespace apache {
+namespace thrift {
+
+class TBase {
+public:
+  virtual ~TBase(){};
+  virtual uint32_t read(::apache::thrift::protocol::TProtocol* iprot) = 0;
+  virtual uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const = 0;
+};
+
+}
+} // apache::thrift
+
+#endif // #ifndef _THRIFT_TBASE_H_


### PR DESCRIPTION
Add a TBase that all Struct's use as their base class.
Contributed by Sentient Technologies - http://www.sentient.ai/